### PR TITLE
Add support for `.ruby-version` and `.ruby-gemset`

### DIFF
--- a/config.py.dist
+++ b/config.py.dist
@@ -10,6 +10,9 @@ SEGMENTS = [
 # Show current virtual environment (see http://www.virtualenv.org/)
     'virtual_env',
 
+# Show current .ruby-version & .ruby-gemset
+    'ruby_gemset',
+
 # Show the current user's username as in ordinary prompts
     'username',
 

--- a/segments/ruby_gemset.py
+++ b/segments/ruby_gemset.py
@@ -1,0 +1,19 @@
+import os
+
+def add_ruby_gemset_segment():
+    if not os.path.isfile(".ruby-version"):
+        return
+
+    with open(".ruby-version") as f:
+        ruby_version = f.read().rstrip()
+
+    if os.path.isfile(".ruby-gemset"):
+        with open(".ruby-gemset") as f:
+            ruby_gemset = f.read().rstrip()
+        ruby_version = ruby_version + "@" + ruby_gemset
+
+    bg = Color.VIRTUAL_ENV_BG
+    fg = Color.VIRTUAL_ENV_FG
+    powerline.append(' %s ' % ruby_version, fg, bg)
+
+add_ruby_gemset_segment()


### PR DESCRIPTION
Added `ruby_gemset` segment to display RVM's `.ruby-version` and `.ruby-gemset` settings, if they exist.